### PR TITLE
Fixed doc string

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -4,8 +4,8 @@ app = FastAPI()
 
 
 @app.websocket("/")
-async def websocket_endpoint(websocket: WebSocket):
-    """This function is called when a websocket is opened."""
+async def root(websocket: WebSocket):
+    """This function is called when a websocket connection is made to http://localhost:8000/ (root of the api)."""
     await websocket.accept()
 
     while True:


### PR DESCRIPTION
Doc string was not accurate. It said that it was called when a websocket was opened. That is partially true, but it only is opened when a connection is made to the root of the api.